### PR TITLE
Remove drupal-packagist.webflo.io in favor of packagist.drupal-composer.org

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,10 +4,6 @@
   "repositories": [
     {
       "type": "composer",
-      "url": "http://drupal-packagist.webflo.io/"
-    },
-    {
-      "type": "composer",
       "url": "http://packagist.drupal-composer.org"
     }
   ],


### PR DESCRIPTION
Is this related to https://github.com/drupal-composer/drupal-parse-composer/issues/29? Maybe the duplicate repo definition cause some problems?
